### PR TITLE
Extends reset() selector capabilities + Custom (Key)words

### DIFF
--- a/microlight.js
+++ b/microlight.js
@@ -36,9 +36,12 @@
 
 
     
-    var reset = function(cls) {
+    var reset = function(cls = 'microlight') {
         // nodes to highlight
-        microlighted = _document.getElementsByClassName(cls||'microlight');
+        microlighted = !cls || typeof cls === 'string' ?
+            _document.getElementsByClassName(cls) :
+            cls.selector ? _document.querySelectorAll(cls.selector) :
+            typeof cls[Symbol.iterator] === 'function' ? cls : [cls];
 
         for (i = 0; el = microlighted[i++];) {
             var text  = el.textContent,

--- a/microlight.js
+++ b/microlight.js
@@ -36,7 +36,7 @@
 
 
     
-    var reset = function(cls = 'microlight') {
+    var reset = function(cls = 'microlight', cwords = []) {
         // nodes to highlight
         microlighted = !cls || typeof cls === 'string' ?
             _document.getElementsByClassName(cls) :
@@ -151,6 +151,8 @@
                             tokenType > 6 ? 4 :
                             // regex and strings
                             tokenType > 3 ? 3 :
+                            // is a custom word
+                            cwords.includes(token) ? 1 :                            
                             // otherwise tokenType == 3, (key)word
                             // (1 if regexp matches, 0 otherwise)
                             + /^(a(bstract|lias|nd|rguments|rray|s(m|sert)?|uto)|b(ase|egin|ool(ean)?|reak|yte)|c(ase|atch|har|hecked|lass|lone|ompl|onst|ontinue)|de(bugger|cimal|clare|f(ault|er)?|init|l(egate|ete)?)|do|double|e(cho|ls?if|lse(if)?|nd|nsure|num|vent|x(cept|ec|p(licit|ort)|te(nds|nsion|rn)))|f(allthrough|alse|inal(ly)?|ixed|loat|or(each)?|riend|rom|unc(tion)?)|global|goto|guard|i(f|mp(lements|licit|ort)|n(it|clude(_once)?|line|out|stanceof|t(erface|ernal)?)?|s)|l(ambda|et|ock|ong)|m(icrolight|odule|utable)|NaN|n(amespace|ative|ext|ew|il|ot|ull)|o(bject|perator|r|ut|verride)|p(ackage|arams|rivate|rotected|rotocol|ublic)|r(aise|e(adonly|do|f|gister|peat|quire(_once)?|scue|strict|try|turn))|s(byte|ealed|elf|hort|igned|izeof|tatic|tring|truct|ubscript|uper|ynchronized|witch)|t(emplate|hen|his|hrows?|ransient|rue|ry|ype(alias|def|id|name|of))|u(n(checked|def(ined)?|ion|less|signed|til)|se|sing)|v(ar|irtual|oid|olatile)|w(char_t|hen|here|hile|ith)|xor|yield)$/[test](token)


### PR DESCRIPTION
This PR adds two new features. I know is not a good ideia to send a double feature PR, but since it shares some lines between modifications and is a very small PR as well, im sending a single one to avoid rebase or conflicts. In case to not accept any mod, its just deny, in case to accept only one, i can split them.

1. It extends the capabilities of reset selector to the following situations:

```js
// same behavior (retrocompatibility)
microlight.reset(); 

// same behavior (retrocompatibility)
microlight.reset('whatever');

// can use any valid selector (will try querySelectorAll)
microlight.reset({ selector: '[code-lang=javascript]' });
microlight.reset({ selector: 'code.language-html' };

// can directly pass an object array or node list
microlight.reset(document.querySelectorAll('code.highlight'))

// can pass a single element/node
microlight.reset(document.querySelector('div.single-node-highlight'));
```  
The motivation for this feature is to let this library to be used in many situations that we have no full control of the html output (as in some doc/static generators, for example). It can be useful to determine the targets with accuracy when by class is not a possible option.

2. Adds the capability to pass a custom wordlist to highlight (incrementally)

Turns the second parameter into a custom case sensitive wordlist. The wordlist must be an array of strings which will be highlighted as tokenType 1:

```js
microlight.reset('whatever', [
  'npm',
  'install',
  'run',
]);
```

This will highlight the "npm", "install" and "run" words. The motivation for this feature is to extend the lib capabilities to deal with almost any situation/language.

---

I believe that this two features together can empower the lib in such a way that user can have a lot of flexibility and also create cool things like a snippet that highlights bash npm commands only on code tags, for example:

```js
microlight.reset({ selector: 'code.npm-snippet' }, [
  'npm', 'install', 'run', 'uninstall', 'publish'
]);
```
